### PR TITLE
Fix #37: Constant time implementation of public key comparison

### DIFF
--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/crypto/Sike.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/crypto/Sike.java
@@ -113,6 +113,7 @@ public class Sike {
         PrivateKey rKey = new SidhPrivateKey(sikeParam, Party.ALICE, key);
         PublicKey c0Key = keyGenerator.derivePublicKey(Party.ALICE, rKey);
         byte[] k;
+        // The public key equals method runs in constant time
         if (c0Key.equals(encrypted.getC0())) {
             k = generateK(m, c0Key.getEncoded(), encrypted.getC1());
         } else {

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/Fp2PointProjective.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/Fp2PointProjective.java
@@ -110,8 +110,8 @@ public class Fp2PointProjective implements Fp2Point {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Fp2PointProjective that = (Fp2PointProjective) o;
-        return x.equals(that.x) &&
-                z.equals(that.z);
+        // Use & to avoid timing attacks
+        return x.equals(that.x) & z.equals(that.z);
     }
 
     @Override

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/fp/Fp2ElementOpti.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/fp/Fp2ElementOpti.java
@@ -19,7 +19,7 @@ package com.wultra.security.pqc.sike.math.optimized.fp;
 import com.wultra.security.pqc.sike.math.api.Fp2Element;
 import com.wultra.security.pqc.sike.math.api.FpElement;
 import com.wultra.security.pqc.sike.param.SikeParam;
-import org.bouncycastle.util.Arrays;
+import com.wultra.security.pqc.sike.util.SideChannelUtil;
 
 import java.math.BigInteger;
 import java.util.Objects;
@@ -282,7 +282,7 @@ public class Fp2ElementOpti implements Fp2Element {
         Fp2ElementOpti that = (Fp2ElementOpti) o;
         // Use constant time comparison to avoid timing attacks
         return sikeParam.equals(that.sikeParam)
-                && Arrays.constantTimeAreEqual(getEncoded(), that.getEncoded());
+                && SideChannelUtil.constantTimeAreEqual(getEncoded(), that.getEncoded());
     }
 
     @Override

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/fp/Fp2ElementOpti.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/fp/Fp2ElementOpti.java
@@ -19,6 +19,7 @@ package com.wultra.security.pqc.sike.math.optimized.fp;
 import com.wultra.security.pqc.sike.math.api.Fp2Element;
 import com.wultra.security.pqc.sike.math.api.FpElement;
 import com.wultra.security.pqc.sike.param.SikeParam;
+import org.bouncycastle.util.Arrays;
 
 import java.math.BigInteger;
 import java.util.Objects;
@@ -279,9 +280,9 @@ public class Fp2ElementOpti implements Fp2Element {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Fp2ElementOpti that = (Fp2ElementOpti) o;
+        // Use constant time comparison to avoid timing attacks
         return sikeParam.equals(that.sikeParam)
-                && x0.equals(that.x0)
-                && x1.equals(that.x1);
+                && Arrays.constantTimeAreEqual(getEncoded(), that.getEncoded());
     }
 
     @Override

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/fp/FpElementOpti.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/fp/FpElementOpti.java
@@ -20,6 +20,7 @@ import com.wultra.security.pqc.sike.math.api.FpElement;
 import com.wultra.security.pqc.sike.param.SikeParam;
 import com.wultra.security.pqc.sike.util.ByteEncoding;
 import com.wultra.security.pqc.sike.util.OctetEncoding;
+import com.wultra.security.pqc.sike.util.SideChannelUtil;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -271,7 +272,7 @@ public class FpElementOpti implements FpElement {
     @Override
     public boolean isZero() {
         FpElement zero = new FpElementOpti(sikeParam, new long[value.length]);
-        return org.bouncycastle.util.Arrays.constantTimeAreEqual(zero.getEncoded(), getEncoded());
+        return SideChannelUtil.constantTimeAreEqual(zero.getEncoded(), getEncoded());
     }
 
     /**
@@ -422,7 +423,7 @@ public class FpElementOpti implements FpElement {
         }
         FpElementOpti that = (FpElementOpti) o;
         // Use constant time comparison to avoid timing attacks
-        return org.bouncycastle.util.Arrays.constantTimeAreEqual(getX().toByteArray(), that.getX().toByteArray());
+        return SideChannelUtil.constantTimeAreEqual(getX().toByteArray(), that.getX().toByteArray());
     }
 
     @Override

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/fp/FpElementOpti.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/fp/FpElementOpti.java
@@ -423,7 +423,7 @@ public class FpElementOpti implements FpElement {
         }
         FpElementOpti that = (FpElementOpti) o;
         // Use constant time comparison to avoid timing attacks
-        return SideChannelUtil.constantTimeAreEqual(getX().toByteArray(), that.getX().toByteArray());
+        return SideChannelUtil.constantTimeAreEqual(getEncoded(), that.getEncoded());
     }
 
     @Override

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/fp/FpElementOpti.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/fp/FpElementOpti.java
@@ -270,7 +270,8 @@ public class FpElementOpti implements FpElement {
 
     @Override
     public boolean isZero() {
-        return Arrays.equals(new long[value.length], value);
+        FpElement zero = new FpElementOpti(sikeParam, new long[value.length]);
+        return org.bouncycastle.util.Arrays.constantTimeAreEqual(zero.getEncoded(), getEncoded());
     }
 
     /**
@@ -419,8 +420,9 @@ public class FpElementOpti implements FpElement {
         if (!(o instanceof FpElementOpti)) {
             return false;
         }
-        FpElementOpti other = (FpElementOpti) o;
-        return getX().equals(other.getX());
+        FpElementOpti that = (FpElementOpti) o;
+        // Use constant time comparison to avoid timing attacks
+        return org.bouncycastle.util.Arrays.constantTimeAreEqual(getX().toByteArray(), that.getX().toByteArray());
     }
 
     @Override

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/fp/FpElementOpti.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/fp/FpElementOpti.java
@@ -272,7 +272,7 @@ public class FpElementOpti implements FpElement {
     @Override
     public boolean isZero() {
         FpElement zero = new FpElementOpti(sikeParam, new long[value.length]);
-        return SideChannelUtil.constantTimeAreEqual(zero.getEncoded(), getEncoded());
+        return equals(zero);
     }
 
     /**

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/model/EncapsulationResult.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/model/EncapsulationResult.java
@@ -60,7 +60,8 @@ public class EncapsulationResult {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         EncapsulationResult that = (EncapsulationResult) o;
-        return Arrays.equals(secret, that.secret) &&
+        // Use constant time comparison to avoid timing attacks
+        return org.bouncycastle.util.Arrays.constantTimeAreEqual(secret, that.secret) &
                 encryptedMessage.equals(that.encryptedMessage);
     }
 

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/model/EncapsulationResult.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/model/EncapsulationResult.java
@@ -16,6 +16,8 @@
  */
 package com.wultra.security.pqc.sike.model;
 
+import com.wultra.security.pqc.sike.util.SideChannelUtil;
+
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -61,7 +63,7 @@ public class EncapsulationResult {
         if (o == null || getClass() != o.getClass()) return false;
         EncapsulationResult that = (EncapsulationResult) o;
         // Use constant time comparison to avoid timing attacks
-        return org.bouncycastle.util.Arrays.constantTimeAreEqual(secret, that.secret) &
+        return SideChannelUtil.constantTimeAreEqual(secret, that.secret) &
                 encryptedMessage.equals(that.encryptedMessage);
     }
 

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/model/EncryptedMessage.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/model/EncryptedMessage.java
@@ -17,6 +17,7 @@
 package com.wultra.security.pqc.sike.model;
 
 import com.wultra.security.pqc.sike.param.SikeParam;
+import com.wultra.security.pqc.sike.util.SideChannelUtil;
 
 import java.security.InvalidParameterException;
 import java.security.PublicKey;
@@ -103,7 +104,7 @@ public class EncryptedMessage {
         if (o == null || getClass() != o.getClass()) return false;
         EncryptedMessage that = (EncryptedMessage) o;
         // Use constant time comparison to avoid timing attacks
-        return org.bouncycastle.util.Arrays.constantTimeAreEqual(getEncoded(), that.getEncoded());
+        return SideChannelUtil.constantTimeAreEqual(getEncoded(), that.getEncoded());
     }
 
     @Override

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/model/EncryptedMessage.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/model/EncryptedMessage.java
@@ -102,8 +102,8 @@ public class EncryptedMessage {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         EncryptedMessage that = (EncryptedMessage) o;
-        return c0.equals(that.c0) &&
-                Arrays.equals(c1, that.c1);
+        // Use constant time comparison to avoid timing attacks
+        return org.bouncycastle.util.Arrays.constantTimeAreEqual(getEncoded(), that.getEncoded());
     }
 
     @Override

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/model/EvaluatedCurve.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/model/EvaluatedCurve.java
@@ -101,10 +101,11 @@ public class EvaluatedCurve {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         EvaluatedCurve that = (EvaluatedCurve) o;
+        // Use & to avoid timing attacks
         return curve.equals(that.curve)
-                && Objects.equals(p, that.p)
-                && Objects.equals(q, that.q)
-                && Objects.equals(r, that.r);
+                & Objects.equals(p, that.p)
+                & Objects.equals(q, that.q)
+                & Objects.equals(r, that.r);
     }
 
     @Override

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/model/SidhPrivateKey.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/model/SidhPrivateKey.java
@@ -20,6 +20,7 @@ import com.wultra.security.pqc.sike.math.api.FpElement;
 import com.wultra.security.pqc.sike.param.SikeParam;
 import com.wultra.security.pqc.sike.util.ByteEncoding;
 import com.wultra.security.pqc.sike.util.OctetEncoding;
+import com.wultra.security.pqc.sike.util.SideChannelUtil;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -232,7 +233,7 @@ public class SidhPrivateKey implements PrivateKey {
         SidhPrivateKey that = (SidhPrivateKey) o;
         // Use constant time comparison to avoid timing attacks
         return sikeParam.equals(that.sikeParam)
-                && org.bouncycastle.util.Arrays.constantTimeAreEqual(getEncoded(), that.getEncoded());
+                && SideChannelUtil.constantTimeAreEqual(getEncoded(), that.getEncoded());
     }
 
     @Override

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/model/SidhPrivateKey.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/model/SidhPrivateKey.java
@@ -25,7 +25,6 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidParameterException;
 import java.security.PrivateKey;
-import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -231,9 +230,9 @@ public class SidhPrivateKey implements PrivateKey {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SidhPrivateKey that = (SidhPrivateKey) o;
+        // Use constant time comparison to avoid timing attacks
         return sikeParam.equals(that.sikeParam)
-                && Arrays.equals(s, that.s)
-                && Arrays.equals(key, that.key);
+                && org.bouncycastle.util.Arrays.constantTimeAreEqual(getEncoded(), that.getEncoded());
     }
 
     @Override

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/model/SidhPublicKey.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/model/SidhPublicKey.java
@@ -20,6 +20,7 @@ import com.wultra.security.pqc.sike.math.api.Fp2Element;
 import com.wultra.security.pqc.sike.param.SikeParam;
 import com.wultra.security.pqc.sike.util.ByteEncoding;
 import com.wultra.security.pqc.sike.util.OctetEncoding;
+import org.bouncycastle.util.Arrays;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -168,11 +169,10 @@ public class SidhPublicKey implements PublicKey {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        SidhPublicKey publicKey = (SidhPublicKey) o;
-        return sikeParam.equals(publicKey.sikeParam)
-                && px.equals(publicKey.px)
-                && qx.equals(publicKey.qx)
-                && rx.equals(publicKey.rx);
+        SidhPublicKey that = (SidhPublicKey) o;
+        // Use constant time comparison to avoid timing attacks
+        return sikeParam.equals(that.sikeParam)
+                && Arrays.constantTimeAreEqual(getEncoded(), that.getEncoded());
     }
 
     @Override

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/util/SideChannelUtil.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/util/SideChannelUtil.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.pqc.sike.util;
+
+import org.bouncycastle.util.Arrays;
+
+/**
+ * Utilities for preventing side channel attacks.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class SideChannelUtil {
+
+    /**
+     * Compare two byte arrays in constant time.
+     * @param bytes1 First byte array.
+     * @param bytes2 Second byte array.
+     * @return Whether byte arrays are equal.
+     */
+    public static boolean constantTimeAreEqual(byte[] bytes1, byte[] bytes2) {
+        return Arrays.constantTimeAreEqual(bytes1, bytes2);
+    }
+}


### PR DESCRIPTION
Constant time comparison is now used in optimized implementation wherever it makes sense.