### PR TITLE
Fix #52: Fix double checked locking when constructing SecureRandom

### DIFF
--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/crypto/RandomGenerator.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/crypto/RandomGenerator.java
@@ -27,7 +27,7 @@ import java.security.SecureRandom;
  */
 public class RandomGenerator {
 
-    private SecureRandom secureRandom;
+    private volatile SecureRandom secureRandom;
 
     /**
      * Default random generator constructor.


### PR DESCRIPTION
I added the missing `volatile` keyword.