### PR TITLE
Fix #54: private no-arg constructor to utility classes

### DIFF
--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/fp/UnsignedLong.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/fp/UnsignedLong.java
@@ -24,6 +24,10 @@ package com.wultra.security.pqc.sike.math.optimized.fp;
  */
 public class UnsignedLong {
 
+    private UnsignedLong() {
+
+    }
+
     /**
      * Add two unsigned long values with carry.
      * @param x First unsigned long value.

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/util/ByteEncoding.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/util/ByteEncoding.java
@@ -28,6 +28,10 @@ import java.security.InvalidParameterException;
  */
 public class ByteEncoding {
 
+    private ByteEncoding() {
+
+    }
+
     /**
      * Convert unsigned number from byte array. The byte array is stored in big-endian ordering.
      *

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/util/OctetEncoding.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/util/OctetEncoding.java
@@ -26,6 +26,10 @@ import java.security.InvalidParameterException;
  */
 public class OctetEncoding {
 
+    private OctetEncoding() {
+
+    }
+
     /**
      * Convert a BigInteger into octet string.
      *

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/util/Sha3.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/util/Sha3.java
@@ -25,6 +25,10 @@ import org.bouncycastle.crypto.digests.SHAKEDigest;
  */
 public class Sha3 {
 
+    private Sha3() {
+        
+    }
+
     /**
      * Hash data using SHAKE256.
      * @param data Data to hash.

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/util/SideChannelUtil.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/util/SideChannelUtil.java
@@ -25,6 +25,10 @@ import org.bouncycastle.util.Arrays;
  */
 public class SideChannelUtil {
 
+    private SideChannelUtil() {
+        
+    }
+
     /**
      * Compare two byte arrays in constant time.
      * @param bytes1 First byte array.


### PR DESCRIPTION
These classes should not be instantiated directly. An `IllegalStateException()` will be thrown in this case.