### PR TITLE
Made it compatible with older versions of Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ As the first step, initialize the Bouncy Castle provider:
 Security.addProvider(new BouncyCastleProvider());
 ```
 
+On Android, first remove the default Bouncy Castle provider:
+
+```java
+Security.removeProvider("BC");
+Security.addProvider(new BouncyCastleProvider());
+```
+
+
 Initialize Bouncy Castle at the application start before using any of the SIKE for Java functionality.
 
 Before generating keys, choose one of the available algorithm parameter sets depending on the desired NIST security level and parameter size (in bytes):

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/fp/FpElementOpti.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/math/optimized/fp/FpElementOpti.java
@@ -69,7 +69,7 @@ public class FpElementOpti implements FpElement {
         for (int i = 0; i < primeSize; i++) {
             int j = i / 8;
             int k = i % 8;
-            value[j] |= (Byte.toUnsignedLong(encoded[i]) << (8 * k));
+            value[j] |= ((encoded[i] & 0xFFL) << (8 * k));
         }
         FpElementOpti a = new FpElementOpti(sikeParam, value);
         FpElementOpti b = (FpElementOpti) a.multiply(sikeParam.getPR2());

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/param/SikeParamP434.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/param/SikeParamP434.java
@@ -261,13 +261,13 @@ public class SikeParamP434 implements SikeParam {
     }
 
     private final FpElementOpti p = new FpElementOpti(this, new long[]{
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FDC1767AE2FFFFFF", 16),
-            Long.parseUnsignedLong("7BC65C783158AEA3", 16),
-            Long.parseUnsignedLong("6CFC5FD681C52056", 16),
-            Long.parseUnsignedLong("0002341F27177344", 16)
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xFDC1767AE2FFFFFFL,
+            0x7BC65C783158AEA3L,
+            0x6CFC5FD681C52056L,
+            0x0002341F27177344L
     });
 
     @Override
@@ -276,13 +276,13 @@ public class SikeParamP434 implements SikeParam {
     }
 
     private final FpElementOpti p1 = new FpElementOpti(this, new long[]{
-            Long.parseUnsignedLong("0000000000000000", 16),
-            Long.parseUnsignedLong("0000000000000000", 16),
-            Long.parseUnsignedLong("0000000000000000", 16),
-            Long.parseUnsignedLong("FDC1767AE3000000", 16),
-            Long.parseUnsignedLong("7BC65C783158AEA3", 16),
-            Long.parseUnsignedLong("6CFC5FD681C52056", 16),
-            Long.parseUnsignedLong("0002341F27177344", 16)
+            0x0000000000000000L,
+            0x0000000000000000L,
+            0x0000000000000000L,
+            0xFDC1767AE3000000L,
+            0x7BC65C783158AEA3L,
+            0x6CFC5FD681C52056L,
+            0x0002341F27177344L
     });
 
     @Override
@@ -291,13 +291,13 @@ public class SikeParamP434 implements SikeParam {
     }
 
     private final FpElementOpti px2 = new FpElementOpti(this, new long[]{
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFE", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FB82ECF5C5FFFFFF", 16),
-            Long.parseUnsignedLong("F78CB8F062B15D47", 16),
-            Long.parseUnsignedLong("D9F8BFAD038A40AC", 16),
-            Long.parseUnsignedLong("0004683E4E2EE688", 16)
+            0xFFFFFFFFFFFFFFFEL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xFB82ECF5C5FFFFFFL,
+            0xF78CB8F062B15D47L,
+            0xD9F8BFAD038A40ACL,
+            0x0004683E4E2EE688L
     });
 
     @Override
@@ -306,13 +306,13 @@ public class SikeParamP434 implements SikeParam {
     }
 
     private final FpElementOpti pr2 = new FpElementOpti(this, new long[]{
-            Long.parseUnsignedLong("28E55B65DCD69B30", 16),
-            Long.parseUnsignedLong("ACEC7367768798C2", 16),
-            Long.parseUnsignedLong("AB27973F8311688D", 16),
-            Long.parseUnsignedLong("175CC6AF8D6C7C0B", 16),
-            Long.parseUnsignedLong("ABCD92BF2DDE347E", 16),
-            Long.parseUnsignedLong("69E16A61C7686D9A", 16),
-            Long.parseUnsignedLong("000025A89BCDD12A", 16)
+            0x28E55B65DCD69B30L,
+            0xACEC7367768798C2L,
+            0xAB27973F8311688DL,
+            0x175CC6AF8D6C7C0BL,
+            0xABCD92BF2DDE347EL,
+            0x69E16A61C7686D9AL,
+            0x000025A89BCDD12AL
     });
 
     @Override
@@ -386,115 +386,115 @@ public class SikeParamP434 implements SikeParam {
             PUBLIC_POINT_RB = new Fp2PointAffine(new Fp2ElementRef(this, PUBLIC_POINT_RB_X0, PUBLIC_POINT_RB_X1), new Fp2ElementRef(this, PUBLIC_POINT_RB_Y0, PUBLIC_POINT_RB_Y1));
         } else {
             FpElement PUBLIC_POINT_PA_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("05ADF455C5C345BF", 16),
-                    Long.parseUnsignedLong("91935C5CC767AC2B", 16),
-                    Long.parseUnsignedLong("AFE4E879951F0257", 16),
-                    Long.parseUnsignedLong("70E792DC89FA27B1", 16),
-                    Long.parseUnsignedLong("F797F526BB48C8CD", 16),
-                    Long.parseUnsignedLong("2181DB6131AF621F", 16),
-                    Long.parseUnsignedLong("00000A1C08B1ECC4", 16)
+                    0x05ADF455C5C345BFL,
+                    0x91935C5CC767AC2BL,
+                    0xAFE4E879951F0257L,
+                    0x70E792DC89FA27B1L,
+                    0xF797F526BB48C8CDL,
+                    0x2181DB6131AF621FL,
+                    0x00000A1C08B1ECC4L
             });
             FpElement PUBLIC_POINT_PA_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("74840EB87CDA7788", 16),
-                    Long.parseUnsignedLong("2971AA0ECF9F9D0B", 16),
-                    Long.parseUnsignedLong("CB5732BDF41715D5", 16),
-                    Long.parseUnsignedLong("8CD8E51F7AACFFAA", 16),
-                    Long.parseUnsignedLong("A7F424730D7E419F", 16),
-                    Long.parseUnsignedLong("D671EB919A179E8C", 16),
-                    Long.parseUnsignedLong("0000FFA26C5A924A", 16)
+                    0x74840EB87CDA7788L,
+                    0x2971AA0ECF9F9D0BL,
+                    0xCB5732BDF41715D5L,
+                    0x8CD8E51F7AACFFAAL,
+                    0xA7F424730D7E419FL,
+                    0xD671EB919A179E8CL,
+                    0x0000FFA26C5A924AL
             });
             FpElement PUBLIC_POINT_QA_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("FEC6E64588B7273B", 16),
-                    Long.parseUnsignedLong("D2A626D74CBBF1C6", 16),
-                    Long.parseUnsignedLong("F8F58F07A78098C7", 16),
-                    Long.parseUnsignedLong("E23941F470841B03", 16),
-                    Long.parseUnsignedLong("1B63EDA2045538DD", 16),
-                    Long.parseUnsignedLong("735CFEB0FFD49215", 16),
-                    Long.parseUnsignedLong("0001C4CB77542876", 16)
+                    0xFEC6E64588B7273BL,
+                    0xD2A626D74CBBF1C6L,
+                    0xF8F58F07A78098C7L,
+                    0xE23941F470841B03L,
+                    0x1B63EDA2045538DDL,
+                    0x735CFEB0FFD49215L,
+                    0x0001C4CB77542876L
             });
             FpElement PUBLIC_POINT_QA_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("ADB0F733C17FFDD6", 16),
-                    Long.parseUnsignedLong("6AFFBD037DA0A050", 16),
-                    Long.parseUnsignedLong("680EC43DB144E02F", 16),
-                    Long.parseUnsignedLong("1E2E5D5FF524E374", 16),
-                    Long.parseUnsignedLong("E2DDA115260E2995", 16),
-                    Long.parseUnsignedLong("A6E4B552E2EDE508", 16),
-                    Long.parseUnsignedLong("00018ECCDDF4B53E", 16)
+                    0xADB0F733C17FFDD6L,
+                    0x6AFFBD037DA0A050L,
+                    0x680EC43DB144E02FL,
+                    0x1E2E5D5FF524E374L,
+                    0xE2DDA115260E2995L,
+                    0xA6E4B552E2EDE508L,
+                    0x00018ECCDDF4B53EL
             });
             FpElement PUBLIC_POINT_RA_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("01BA4DB518CD6C7D", 16),
-                    Long.parseUnsignedLong("2CB0251FE3CC0611", 16),
-                    Long.parseUnsignedLong("259B0C6949A9121B", 16),
-                    Long.parseUnsignedLong("60E17AC16D2F82AD", 16),
-                    Long.parseUnsignedLong("3AA41F1CE175D92D", 16),
-                    Long.parseUnsignedLong("413FBE6A9B9BC4F3", 16),
-                    Long.parseUnsignedLong("00022A81D8D55643", 16)
+                    0x01BA4DB518CD6C7DL,
+                    0x2CB0251FE3CC0611L,
+                    0x259B0C6949A9121BL,
+                    0x60E17AC16D2F82ADL,
+                    0x3AA41F1CE175D92DL,
+                    0x413FBE6A9B9BC4F3L,
+                    0x00022A81D8D55643L
             });
             FpElement PUBLIC_POINT_RA_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("B8ADBC70FC82E54A", 16),
-                    Long.parseUnsignedLong("EF9CDDB0D5FADDED", 16),
-                    Long.parseUnsignedLong("5820C734C80096A0", 16),
-                    Long.parseUnsignedLong("7799994BAA96E0E4", 16),
-                    Long.parseUnsignedLong("044961599E379AF8", 16),
-                    Long.parseUnsignedLong("DB2B94FBF09F27E2", 16),
-                    Long.parseUnsignedLong("0000B87FC716C0C6", 16)
+                    0xB8ADBC70FC82E54AL,
+                    0xEF9CDDB0D5FADDEDL,
+                    0x5820C734C80096A0L,
+                    0x7799994BAA96E0E4L,
+                    0x044961599E379AF8L,
+                    0xDB2B94FBF09F27E2L,
+                    0x0000B87FC716C0C6L
             });
             PUBLIC_POINT_PA = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_PA_X0, PUBLIC_POINT_PA_X1), fp2ElementFactory.one());
             PUBLIC_POINT_QA = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_QA_X0, PUBLIC_POINT_QA_X1), fp2ElementFactory.one());
             PUBLIC_POINT_RA = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_RA_X0, PUBLIC_POINT_RA_X1), fp2ElementFactory.one());
             FpElement PUBLIC_POINT_PB_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("6E5497556EDD48A3", 16),
-                    Long.parseUnsignedLong("2A61B501546F1C05", 16),
-                    Long.parseUnsignedLong("EB919446D049887D", 16),
-                    Long.parseUnsignedLong("5864A4A69D450C4F", 16),
-                    Long.parseUnsignedLong("B883F276A6490D2B", 16),
-                    Long.parseUnsignedLong("22CC287022D5F5B9", 16),
-                    Long.parseUnsignedLong("0001BED4772E551F", 16)
+                    0x6E5497556EDD48A3L,
+                    0x2A61B501546F1C05L,
+                    0xEB919446D049887DL,
+                    0x5864A4A69D450C4FL,
+                    0xB883F276A6490D2BL,
+                    0x22CC287022D5F5B9L,
+                    0x0001BED4772E551FL
             });
             FpElement PUBLIC_POINT_PB_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16)
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L
             });
             FpElement PUBLIC_POINT_QB_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("FAE2A3F93D8B6B8E", 16),
-                    Long.parseUnsignedLong("494871F51700FE1C", 16),
-                    Long.parseUnsignedLong("EF1A94228413C27C", 16),
-                    Long.parseUnsignedLong("498FF4A4AF60BD62", 16),
-                    Long.parseUnsignedLong("B00AD2A708267E8A", 16),
-                    Long.parseUnsignedLong("F4328294E017837F", 16),
-                    Long.parseUnsignedLong("000034080181D8AE", 16)
+                    0xFAE2A3F93D8B6B8EL,
+                    0x494871F51700FE1CL,
+                    0xEF1A94228413C27CL,
+                    0x498FF4A4AF60BD62L,
+                    0xB00AD2A708267E8AL,
+                    0xF4328294E017837FL,
+                    0x000034080181D8AEL
             });
             FpElement PUBLIC_POINT_QB_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16)
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L
             });
             FpElement PUBLIC_POINT_RB_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("283B34FAFEFDC8E4", 16),
-                    Long.parseUnsignedLong("9208F44977C3E647", 16),
-                    Long.parseUnsignedLong("7DEAE962816F4E9A", 16),
-                    Long.parseUnsignedLong("68A2BA8AA262EC9D", 16),
-                    Long.parseUnsignedLong("8176F112EA43F45B", 16),
-                    Long.parseUnsignedLong("02106D022634F504", 16),
-                    Long.parseUnsignedLong("00007E8A50F02E37", 16)
+                    0x283B34FAFEFDC8E4L,
+                    0x9208F44977C3E647L,
+                    0x7DEAE962816F4E9AL,
+                    0x68A2BA8AA262EC9DL,
+                    0x8176F112EA43F45BL,
+                    0x02106D022634F504L,
+                    0x00007E8A50F02E37L
             });
             FpElement PUBLIC_POINT_RB_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("B378B7C1DA22CCB1", 16),
-                    Long.parseUnsignedLong("6D089C99AD1D9230", 16),
-                    Long.parseUnsignedLong("EBE15711813E2369", 16),
-                    Long.parseUnsignedLong("2B35A68239D48A53", 16),
-                    Long.parseUnsignedLong("445F6FD138407C93", 16),
-                    Long.parseUnsignedLong("BEF93B29A3F6B54B", 16),
-                    Long.parseUnsignedLong("000173FA910377D3", 16)
+                    0xB378B7C1DA22CCB1L,
+                    0x6D089C99AD1D9230L,
+                    0xEBE15711813E2369L,
+                    0x2B35A68239D48A53L,
+                    0x445F6FD138407C93L,
+                    0xBEF93B29A3F6B54BL,
+                    0x000173FA910377D3L
             });
             PUBLIC_POINT_PB = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_PB_X0, PUBLIC_POINT_PB_X1), fp2ElementFactory.one());
             PUBLIC_POINT_QB = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_QB_X0, PUBLIC_POINT_QB_X1), fp2ElementFactory.one());

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/param/SikeParamP503.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/param/SikeParamP503.java
@@ -262,14 +262,14 @@ public class SikeParamP503 implements SikeParam {
     }
 
     private final FpElementOpti p = new FpElementOpti(this, new long[]{
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("ABFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("13085BDA2211E7A0", 16),
-            Long.parseUnsignedLong("1B9BF6C87B7E7DAF", 16),
-            Long.parseUnsignedLong("6045C6BDDA77A4D0", 16),
-            Long.parseUnsignedLong("004066F541811E1E", 16)
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xABFFFFFFFFFFFFFFL,
+            0x13085BDA2211E7A0L,
+            0x1B9BF6C87B7E7DAFL,
+            0x6045C6BDDA77A4D0L,
+            0x004066F541811E1EL
     });
 
     @Override
@@ -278,14 +278,14 @@ public class SikeParamP503 implements SikeParam {
     }
 
     private final FpElementOpti p1 = new FpElementOpti(this, new long[]{
-            Long.parseUnsignedLong("0000000000000000", 16),
-            Long.parseUnsignedLong("0000000000000000", 16),
-            Long.parseUnsignedLong("0000000000000000", 16),
-            Long.parseUnsignedLong("AC00000000000000", 16),
-            Long.parseUnsignedLong("13085BDA2211E7A0", 16),
-            Long.parseUnsignedLong("1B9BF6C87B7E7DAF", 16),
-            Long.parseUnsignedLong("6045C6BDDA77A4D0", 16),
-            Long.parseUnsignedLong("004066F541811E1E", 16)
+            0x0000000000000000L,
+            0x0000000000000000L,
+            0x0000000000000000L,
+            0xAC00000000000000L,
+            0x13085BDA2211E7A0L,
+            0x1B9BF6C87B7E7DAFL,
+            0x6045C6BDDA77A4D0L,
+            0x004066F541811E1EL
     });
 
     @Override
@@ -294,14 +294,14 @@ public class SikeParamP503 implements SikeParam {
     }
 
     private final FpElementOpti px2 = new FpElementOpti(this, new long[]{
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFE", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("57FFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("2610B7B44423CF41", 16),
-            Long.parseUnsignedLong("3737ED90F6FCFB5E", 16),
-            Long.parseUnsignedLong("C08B8D7BB4EF49A0", 16),
-            Long.parseUnsignedLong("0080CDEA83023C3C", 16)
+            0xFFFFFFFFFFFFFFFEL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0x57FFFFFFFFFFFFFFL,
+            0x2610B7B44423CF41L,
+            0x3737ED90F6FCFB5EL,
+            0xC08B8D7BB4EF49A0L,
+            0x0080CDEA83023C3CL
     });
 
     @Override
@@ -310,14 +310,14 @@ public class SikeParamP503 implements SikeParam {
     }
 
     private final FpElementOpti pr2 = new FpElementOpti(this, new long[]{
-            Long.parseUnsignedLong("5289A0CF641D011F", 16),
-            Long.parseUnsignedLong("9B88257189FED2B9", 16),
-            Long.parseUnsignedLong("A3B365D58DC8F17A", 16),
-            Long.parseUnsignedLong("5BC57AB6EFF168EC", 16),
-            Long.parseUnsignedLong("9E51998BD84D4423", 16),
-            Long.parseUnsignedLong("BF8999CBAC3B5695", 16),
-            Long.parseUnsignedLong("46E9127BCE14CDB6", 16),
-            Long.parseUnsignedLong("003F6CFCE8B81771", 16)
+            0x5289A0CF641D011FL,
+            0x9B88257189FED2B9L,
+            0xA3B365D58DC8F17AL,
+            0x5BC57AB6EFF168ECL,
+            0x9E51998BD84D4423L,
+            0xBF8999CBAC3B5695L,
+            0x46E9127BCE14CDB6L,
+            0x003F6CFCE8B81771L
     });
 
     @Override
@@ -391,127 +391,127 @@ public class SikeParamP503 implements SikeParam {
             PUBLIC_POINT_RB = new Fp2PointAffine(new Fp2ElementRef(this, PUBLIC_POINT_RB_X0, PUBLIC_POINT_RB_X1), new Fp2ElementRef(this, PUBLIC_POINT_RB_Y0, PUBLIC_POINT_RB_Y1));
         } else {
             FpElement PUBLIC_POINT_PA_X0 = new FpElementOpti(this, new long[]{
-                    Long.parseUnsignedLong("5D083011589AD893", 16),
-                    Long.parseUnsignedLong("ADFD8D2CB67D0637", 16),
-                    Long.parseUnsignedLong("330C9AC34FFB6361", 16),
-                    Long.parseUnsignedLong("F0D47489A2E805A2", 16),
-                    Long.parseUnsignedLong("27E2789259C6B8DC", 16),
-                    Long.parseUnsignedLong("63866A2C121931B9", 16),
-                    Long.parseUnsignedLong("8D4C65A7137DCF44", 16),
-                    Long.parseUnsignedLong("003A183AE5967B3F", 16)
+                    0x5D083011589AD893L,
+                    0xADFD8D2CB67D0637L,
+                    0x330C9AC34FFB6361L,
+                    0xF0D47489A2E805A2L,
+                    0x27E2789259C6B8DCL,
+                    0x63866A2C121931B9L,
+                    0x8D4C65A7137DCF44L,
+                    0x003A183AE5967B3FL
             });
             FpElement PUBLIC_POINT_PA_X1 = new FpElementOpti(this, new long[]{
-                    Long.parseUnsignedLong("7E3541B8C96D1519", 16),
-                    Long.parseUnsignedLong("D3ADAEEC0D61A26C", 16),
-                    Long.parseUnsignedLong("C0A2219CE7703DD9", 16),
-                    Long.parseUnsignedLong("FF3E46658FCDBC52", 16),
-                    Long.parseUnsignedLong("D5B38DEAE6E196FF", 16),
-                    Long.parseUnsignedLong("1AAC826364956D58", 16),
-                    Long.parseUnsignedLong("EC9F4875B9A5F27A", 16),
-                    Long.parseUnsignedLong("001B0B475AB99843", 16)
+                    0x7E3541B8C96D1519L,
+                    0xD3ADAEEC0D61A26CL,
+                    0xC0A2219CE7703DD9L,
+                    0xFF3E46658FCDBC52L,
+                    0xD5B38DEAE6E196FFL,
+                    0x1AAC826364956D58L,
+                    0xEC9F4875B9A5F27AL,
+                    0x001B0B475AB99843L
             });
             FpElement PUBLIC_POINT_QA_X0 = new FpElementOpti(this, new long[]{
-                    Long.parseUnsignedLong("4D83695107D03BAD", 16),
-                    Long.parseUnsignedLong("221F3299005E2FCF", 16),
-                    Long.parseUnsignedLong("78E6AE22F30DECF2", 16),
-                    Long.parseUnsignedLong("6D982DB5111253E4", 16),
-                    Long.parseUnsignedLong("504C80A8AB4526A8", 16),
-                    Long.parseUnsignedLong("EFD0C3AA210BB024", 16),
-                    Long.parseUnsignedLong("CB77483501DC6FCF", 16),
-                    Long.parseUnsignedLong("001052544A96BDF3", 16)
+                    0x4D83695107D03BADL,
+                    0x221F3299005E2FCFL,
+                    0x78E6AE22F30DECF2L,
+                    0x6D982DB5111253E4L,
+                    0x504C80A8AB4526A8L,
+                    0xEFD0C3AA210BB024L,
+                    0xCB77483501DC6FCFL,
+                    0x001052544A96BDF3L
             });
             FpElement PUBLIC_POINT_QA_X1 = new FpElementOpti(this, new long[]{
-                    Long.parseUnsignedLong("0D74FE3402BCAE47", 16),
-                    Long.parseUnsignedLong("DF5B8CDA832D8AED", 16),
-                    Long.parseUnsignedLong("B86BCF06E4BD837E", 16),
-                    Long.parseUnsignedLong("892A2933A0FA1F63", 16),
-                    Long.parseUnsignedLong("9F88FC67B6CCB461", 16),
-                    Long.parseUnsignedLong("822926EA9DDA3AC8", 16),
-                    Long.parseUnsignedLong("EAC8DDE5855425ED", 16),
-                    Long.parseUnsignedLong("000618FE6DA37A80", 16)
+                    0x0D74FE3402BCAE47L,
+                    0xDF5B8CDA832D8AEDL,
+                    0xB86BCF06E4BD837EL,
+                    0x892A2933A0FA1F63L,
+                    0x9F88FC67B6CCB461L,
+                    0x822926EA9DDA3AC8L,
+                    0xEAC8DDE5855425EDL,
+                    0x000618FE6DA37A80L
             });
             FpElement PUBLIC_POINT_RA_X0 = new FpElementOpti(this, new long[]{
-                    Long.parseUnsignedLong("1D9D32D2DC877C17", 16),
-                    Long.parseUnsignedLong("5517CD8F71D5B02B", 16),
-                    Long.parseUnsignedLong("395AFB8F6B60C117", 16),
-                    Long.parseUnsignedLong("3AE31AC85F9098C8", 16),
-                    Long.parseUnsignedLong("5F5341C198450848", 16),
-                    Long.parseUnsignedLong("F8C609DBEA435C6A", 16),
-                    Long.parseUnsignedLong("D832BC7EDC7BA5E4", 16),
-                    Long.parseUnsignedLong("002AD98AA6968BF5", 16)
+                    0x1D9D32D2DC877C17L,
+                    0x5517CD8F71D5B02BL,
+                    0x395AFB8F6B60C117L,
+                    0x3AE31AC85F9098C8L,
+                    0x5F5341C198450848L,
+                    0xF8C609DBEA435C6AL,
+                    0xD832BC7EDC7BA5E4L,
+                    0x002AD98AA6968BF5L
             });
             FpElement PUBLIC_POINT_RA_X1 = new FpElementOpti(this, new long[]{
-                    Long.parseUnsignedLong("C466CAB0F73C2E5B", 16),
-                    Long.parseUnsignedLong("7B1817148FB2CF9C", 16),
-                    Long.parseUnsignedLong("873E87C099E470A0", 16),
-                    Long.parseUnsignedLong("BB17AC6D17A7BAC1", 16),
-                    Long.parseUnsignedLong("A146FDCD0F2E2A58", 16),
-                    Long.parseUnsignedLong("88B311E9CEAB6201", 16),
-                    Long.parseUnsignedLong("37604CF5C7951757", 16),
-                    Long.parseUnsignedLong("0006804071C74BF9", 16)
+                    0xC466CAB0F73C2E5BL,
+                    0x7B1817148FB2CF9CL,
+                    0x873E87C099E470A0L,
+                    0xBB17AC6D17A7BAC1L,
+                    0xA146FDCD0F2E2A58L,
+                    0x88B311E9CEAB6201L,
+                    0x37604CF5C7951757L,
+                    0x0006804071C74BF9L
             });
             PUBLIC_POINT_PA = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_PA_X0, PUBLIC_POINT_PA_X1), fp2ElementFactory.one());
             PUBLIC_POINT_QA = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_QA_X0, PUBLIC_POINT_QA_X1), fp2ElementFactory.one());
             PUBLIC_POINT_RA = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_RA_X0, PUBLIC_POINT_RA_X1), fp2ElementFactory.one());
             FpElement PUBLIC_POINT_PB_X0 = new FpElementOpti(this, new long[]{
-                    Long.parseUnsignedLong("DF630FC5FB2468DB", 16),
-                    Long.parseUnsignedLong("C30C5541C102040E", 16),
-                    Long.parseUnsignedLong("3CDC9987B76511FC", 16),
-                    Long.parseUnsignedLong("F54B5A09353D0CDD", 16),
-                    Long.parseUnsignedLong("3ADBA8E00703C42F", 16),
-                    Long.parseUnsignedLong("8253F9303DDC95D0", 16),
-                    Long.parseUnsignedLong("62D30778763ABFD7", 16),
-                    Long.parseUnsignedLong("001CD00FB581CD55", 16)
+                    0xDF630FC5FB2468DBL,
+                    0xC30C5541C102040EL,
+                    0x3CDC9987B76511FCL,
+                    0xF54B5A09353D0CDDL,
+                    0x3ADBA8E00703C42FL,
+                    0x8253F9303DDC95D0L,
+                    0x62D30778763ABFD7L,
+                    0x001CD00FB581CD55L
             });
             FpElement PUBLIC_POINT_PB_X1 = new FpElementOpti(this, new long[]{
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16)
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L
             });
             FpElement PUBLIC_POINT_QB_X0 = new FpElementOpti(this, new long[]{
-                    Long.parseUnsignedLong("2E3457A12B429261", 16),
-                    Long.parseUnsignedLong("311F94E89627DCF8", 16),
-                    Long.parseUnsignedLong("5B71C98FD1DB73F6", 16),
-                    Long.parseUnsignedLong("3671DB7DCFC21541", 16),
-                    Long.parseUnsignedLong("B6D1484C9FE0CF4F", 16),
-                    Long.parseUnsignedLong("19CD110717356E35", 16),
-                    Long.parseUnsignedLong("F4F9FB00AC9919DF", 16),
-                    Long.parseUnsignedLong("0035BC124D38A70B", 16)
+                    0x2E3457A12B429261L,
+                    0x311F94E89627DCF8L,
+                    0x5B71C98FD1DB73F6L,
+                    0x3671DB7DCFC21541L,
+                    0xB6D1484C9FE0CF4FL,
+                    0x19CD110717356E35L,
+                    0xF4F9FB00AC9919DFL,
+                    0x0035BC124D38A70BL
             });
             FpElement PUBLIC_POINT_QB_X1 = new FpElementOpti(this, new long[]{
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16)
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L
             });
             FpElement PUBLIC_POINT_RB_X0 = new FpElementOpti(this, new long[]{
-                    Long.parseUnsignedLong("2E08BB99413D2952", 16),
-                    Long.parseUnsignedLong("D3021467CD088D72", 16),
-                    Long.parseUnsignedLong("21017AF859752245", 16),
-                    Long.parseUnsignedLong("26314ED8FFD9DE5C", 16),
-                    Long.parseUnsignedLong("4AF43C73344B6686", 16),
-                    Long.parseUnsignedLong("CFA1F91149DF0993", 16),
-                    Long.parseUnsignedLong("F327A95365587A89", 16),
-                    Long.parseUnsignedLong("000DBF54E03D3906", 16)
+                    0x2E08BB99413D2952L,
+                    0xD3021467CD088D72L,
+                    0x21017AF859752245L,
+                    0x26314ED8FFD9DE5CL,
+                    0x4AF43C73344B6686L,
+                    0xCFA1F91149DF0993L,
+                    0xF327A95365587A89L,
+                    0x000DBF54E03D3906L
             });
             FpElement PUBLIC_POINT_RB_X1 = new FpElementOpti(this, new long[]{
-                    Long.parseUnsignedLong("03E03FF342F5F304", 16),
-                    Long.parseUnsignedLong("993D604D7B4B6E56", 16),
-                    Long.parseUnsignedLong("80412F4D9280E71F", 16),
-                    Long.parseUnsignedLong("0FFDC9EF990B3982", 16),
-                    Long.parseUnsignedLong("E584E64C51604931", 16),
-                    Long.parseUnsignedLong("1374F42AC8B0BBD7", 16),
-                    Long.parseUnsignedLong("07D5BC37DFA41A5F", 16),
-                    Long.parseUnsignedLong("00396CCFD61FD34C", 16)
+                    0x03E03FF342F5F304L,
+                    0x993D604D7B4B6E56L,
+                    0x80412F4D9280E71FL,
+                    0x0FFDC9EF990B3982L,
+                    0xE584E64C51604931L,
+                    0x1374F42AC8B0BBD7L,
+                    0x07D5BC37DFA41A5FL,
+                    0x00396CCFD61FD34CL
             });
             PUBLIC_POINT_PB = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_PB_X0, PUBLIC_POINT_PB_X1), fp2ElementFactory.one());
             PUBLIC_POINT_QB = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_QB_X0, PUBLIC_POINT_QB_X1), fp2ElementFactory.one());

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/param/SikeParamP610.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/param/SikeParamP610.java
@@ -261,16 +261,16 @@ public class SikeParamP610 implements SikeParam {
     }
 
     private final FpElementOpti p = new FpElementOpti(this, new long[]{
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("6E01FFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("B1784DE8AA5AB02E", 16),
-            Long.parseUnsignedLong("9AE7BF45048FF9AB", 16),
-            Long.parseUnsignedLong("B255B2FA10C4252A", 16),
-            Long.parseUnsignedLong("819010C251E7D88C", 16),
-            Long.parseUnsignedLong("000000027BF6A768", 16)
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0x6E01FFFFFFFFFFFFL,
+            0xB1784DE8AA5AB02EL,
+            0x9AE7BF45048FF9ABL,
+            0xB255B2FA10C4252AL,
+            0x819010C251E7D88CL,
+            0x000000027BF6A768L
     });
 
     @Override
@@ -279,16 +279,16 @@ public class SikeParamP610 implements SikeParam {
     }
 
     private final FpElementOpti p1 = new FpElementOpti(this, new long[]{
-            Long.parseUnsignedLong("0000000000000000", 16),
-            Long.parseUnsignedLong("0000000000000000", 16),
-            Long.parseUnsignedLong("0000000000000000", 16),
-            Long.parseUnsignedLong("0000000000000000", 16),
-            Long.parseUnsignedLong("6E02000000000000", 16),
-            Long.parseUnsignedLong("B1784DE8AA5AB02E", 16),
-            Long.parseUnsignedLong("9AE7BF45048FF9AB", 16),
-            Long.parseUnsignedLong("B255B2FA10C4252A", 16),
-            Long.parseUnsignedLong("819010C251E7D88C", 16),
-            Long.parseUnsignedLong("000000027BF6A768", 16)
+            0x0000000000000000L,
+            0x0000000000000000L,
+            0x0000000000000000L,
+            0x0000000000000000L,
+            0x6E02000000000000L,
+            0xB1784DE8AA5AB02EL,
+            0x9AE7BF45048FF9ABL,
+            0xB255B2FA10C4252AL,
+            0x819010C251E7D88CL,
+            0x000000027BF6A768L
     });
 
     @Override
@@ -297,29 +297,29 @@ public class SikeParamP610 implements SikeParam {
     }
 
     private final FpElementOpti px2 = new FpElementOpti(this, new long[]{
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFE", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("DC03FFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("62F09BD154B5605C", 16),
-            Long.parseUnsignedLong("35CF7E8A091FF357", 16),
-            Long.parseUnsignedLong("64AB65F421884A55", 16),
-            Long.parseUnsignedLong("03202184A3CFB119", 16),
-            Long.parseUnsignedLong("00000004F7ED4ED1", 16)
+            0xFFFFFFFFFFFFFFFEL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xDC03FFFFFFFFFFFFL,
+            0x62F09BD154B5605CL,
+            0x35CF7E8A091FF357L,
+            0x64AB65F421884A55L,
+            0x03202184A3CFB119L,
+            0x00000004F7ED4ED1L
     });
 
     private final FpElementOpti pr2 = new FpElementOpti(this, new long[]{
-            Long.parseUnsignedLong("E75F5D201A197727", 16),
-            Long.parseUnsignedLong("E0B85963B627392E", 16),
-            Long.parseUnsignedLong("6BC1707818DE493D", 16),
-            Long.parseUnsignedLong("DC7F419940D1A0C5", 16),
-            Long.parseUnsignedLong("7358030979EDE54A", 16),
-            Long.parseUnsignedLong("84F4BEBDEED75A5C", 16),
-            Long.parseUnsignedLong("7ECCA66E13427B47", 16),
-            Long.parseUnsignedLong("C5BB4E65280080B3", 16),
-            Long.parseUnsignedLong("7019950F516DA19A", 16),
-            Long.parseUnsignedLong("000000008E290FF3", 16)
+            0xE75F5D201A197727L,
+            0xE0B85963B627392EL,
+            0x6BC1707818DE493DL,
+            0xDC7F419940D1A0C5L,
+            0x7358030979EDE54AL,
+            0x84F4BEBDEED75A5CL,
+            0x7ECCA66E13427B47L,
+            0xC5BB4E65280080B3L,
+            0x7019950F516DA19AL,
+            0x000000008E290FF3L
     });
 
     @Override
@@ -398,151 +398,151 @@ public class SikeParamP610 implements SikeParam {
             PUBLIC_POINT_RB = new Fp2PointAffine(new Fp2ElementRef(this, PUBLIC_POINT_RB_X0, PUBLIC_POINT_RB_X1), new Fp2ElementRef(this, PUBLIC_POINT_RB_Y0, PUBLIC_POINT_RB_Y1));
         } else {
             FpElement PUBLIC_POINT_PA_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("5019EC96A75AC57A", 16),
-                    Long.parseUnsignedLong("8AEA0E717712C6F1", 16),
-                    Long.parseUnsignedLong("03C067C819D29E5E", 16),
-                    Long.parseUnsignedLong("59F454425FE307D9", 16),
-                    Long.parseUnsignedLong("6D29215D9AD5E6D4", 16),
-                    Long.parseUnsignedLong("D8C5A27CDC9DD34A", 16),
-                    Long.parseUnsignedLong("972DC274DAB435B3", 16),
-                    Long.parseUnsignedLong("82A597C70A80E10F", 16),
-                    Long.parseUnsignedLong("48175986EFED547F", 16),
-                    Long.parseUnsignedLong("00000000671A3592", 16)
+                    0x5019EC96A75AC57AL,
+                    0x8AEA0E717712C6F1L,
+                    0x03C067C819D29E5EL,
+                    0x59F454425FE307D9L,
+                    0x6D29215D9AD5E6D4L,
+                    0xD8C5A27CDC9DD34AL,
+                    0x972DC274DAB435B3L,
+                    0x82A597C70A80E10FL,
+                    0x48175986EFED547FL,
+                    0x00000000671A3592L
             });
             FpElement PUBLIC_POINT_PA_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("E4BA9CC3EEEC53F4", 16),
-                    Long.parseUnsignedLong("BD34E4FEDB0132D3", 16),
-                    Long.parseUnsignedLong("1B7125C87BEE960C", 16),
-                    Long.parseUnsignedLong("25D615BF3CFAA355", 16),
-                    Long.parseUnsignedLong("FC8EC20DC367D66A", 16),
-                    Long.parseUnsignedLong("B44F3FD1CC73289C", 16),
-                    Long.parseUnsignedLong("D84BF51195C2E012", 16),
-                    Long.parseUnsignedLong("38D7C756EB370F48", 16),
-                    Long.parseUnsignedLong("BBC236249F94F72A", 16),
-                    Long.parseUnsignedLong("000000013020CC63", 16)
+                    0xE4BA9CC3EEEC53F4L,
+                    0xBD34E4FEDB0132D3L,
+                    0x1B7125C87BEE960CL,
+                    0x25D615BF3CFAA355L,
+                    0xFC8EC20DC367D66AL,
+                    0xB44F3FD1CC73289CL,
+                    0xD84BF51195C2E012L,
+                    0x38D7C756EB370F48L,
+                    0xBBC236249F94F72AL,
+                    0x000000013020CC63L
             });
             FpElement PUBLIC_POINT_QA_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("1D7C945D3DBCC38C", 16),
-                    Long.parseUnsignedLong("9A5F7C12CA8BA5B9", 16),
-                    Long.parseUnsignedLong("1E8F87985B01CBE3", 16),
-                    Long.parseUnsignedLong("D2CABF82F5BC5235", 16),
-                    Long.parseUnsignedLong("3BDE474ECCA9FAA2", 16),
-                    Long.parseUnsignedLong("B98CD975DF9FB0A8", 16),
-                    Long.parseUnsignedLong("444E4464B9C67790", 16),
-                    Long.parseUnsignedLong("CB2E888565CE6AD9", 16),
-                    Long.parseUnsignedLong("DB64FFE2A1C350E2", 16),
-                    Long.parseUnsignedLong("00000001D7532756", 16)
+                    0x1D7C945D3DBCC38CL,
+                    0x9A5F7C12CA8BA5B9L,
+                    0x1E8F87985B01CBE3L,
+                    0xD2CABF82F5BC5235L,
+                    0x3BDE474ECCA9FAA2L,
+                    0xB98CD975DF9FB0A8L,
+                    0x444E4464B9C67790L,
+                    0xCB2E888565CE6AD9L,
+                    0xDB64FFE2A1C350E2L,
+                    0x00000001D7532756L
             });
             FpElement PUBLIC_POINT_QA_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("1E8B3AA2382C9079", 16),
-                    Long.parseUnsignedLong("28CB31E08A943C00", 16),
-                    Long.parseUnsignedLong("E04D02266E8A63E1", 16),
-                    Long.parseUnsignedLong("84A2D260214EF65F", 16),
-                    Long.parseUnsignedLong("D5933DA25018E226", 16),
-                    Long.parseUnsignedLong("BC8BF038928C4BA9", 16),
-                    Long.parseUnsignedLong("91E9D0CB7EAF58A9", 16),
-                    Long.parseUnsignedLong("04A4627B75E008E1", 16),
-                    Long.parseUnsignedLong("58CEF27583E50C2E", 16),
-                    Long.parseUnsignedLong("00000002170DDF44", 16)
+                    0x1E8B3AA2382C9079L,
+                    0x28CB31E08A943C00L,
+                    0xE04D02266E8A63E1L,
+                    0x84A2D260214EF65FL,
+                    0xD5933DA25018E226L,
+                    0xBC8BF038928C4BA9L,
+                    0x91E9D0CB7EAF58A9L,
+                    0x04A4627B75E008E1L,
+                    0x58CEF27583E50C2EL,
+                    0x00000002170DDF44L
             });
             FpElement PUBLIC_POINT_RA_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("261DD0782CEC958D", 16),
-                    Long.parseUnsignedLong("C25B3AE64BBC0311", 16),
-                    Long.parseUnsignedLong("9F21B8A8981B15FE", 16),
-                    Long.parseUnsignedLong("A3C0B52CD5FFC45B", 16),
-                    Long.parseUnsignedLong("5D2E65A016702C6A", 16),
-                    Long.parseUnsignedLong("8C5586CA98722EDE", 16),
-                    Long.parseUnsignedLong("61490A967A6B4B1A", 16),
-                    Long.parseUnsignedLong("FA64E30231F719AF", 16),
-                    Long.parseUnsignedLong("9CEAB8B6301BB2DF", 16),
-                    Long.parseUnsignedLong("00000000CF5AEA7D", 16)
+                    0x261DD0782CEC958DL,
+                    0xC25B3AE64BBC0311L,
+                    0x9F21B8A8981B15FEL,
+                    0xA3C0B52CD5FFC45BL,
+                    0x5D2E65A016702C6AL,
+                    0x8C5586CA98722EDEL,
+                    0x61490A967A6B4B1AL,
+                    0xFA64E30231F719AFL,
+                    0x9CEAB8B6301BB2DFL,
+                    0x00000000CF5AEA7DL
             });
             FpElement PUBLIC_POINT_RA_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("B980435A77B912C0", 16),
-                    Long.parseUnsignedLong("2B4A97F70E0FC873", 16),
-                    Long.parseUnsignedLong("415C7FA4DE96F43C", 16),
-                    Long.parseUnsignedLong("E5EED95643E443FD", 16),
-                    Long.parseUnsignedLong("CBE18DB57C51B354", 16),
-                    Long.parseUnsignedLong("51C96C3FFABD2D46", 16),
-                    Long.parseUnsignedLong("5C14637B9A5765D6", 16),
-                    Long.parseUnsignedLong("45D2369C4D0199A5", 16),
-                    Long.parseUnsignedLong("25A1F9C5BBF1E683", 16),
-                    Long.parseUnsignedLong("000000025AD7A11B", 16)
+                    0xB980435A77B912C0L,
+                    0x2B4A97F70E0FC873L,
+                    0x415C7FA4DE96F43CL,
+                    0xE5EED95643E443FDL,
+                    0xCBE18DB57C51B354L,
+                    0x51C96C3FFABD2D46L,
+                    0x5C14637B9A5765D6L,
+                    0x45D2369C4D0199A5L,
+                    0x25A1F9C5BBF1E683L,
+                    0x000000025AD7A11BL
             });
             PUBLIC_POINT_PA = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_PA_X0, PUBLIC_POINT_PA_X1), fp2ElementFactory.one());
             PUBLIC_POINT_QA = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_QA_X0, PUBLIC_POINT_QA_X1), fp2ElementFactory.one());
             PUBLIC_POINT_RA = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_RA_X0, PUBLIC_POINT_RA_X1), fp2ElementFactory.one());
             FpElement PUBLIC_POINT_PB_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("C6C8E180E41884BA", 16),
-                    Long.parseUnsignedLong("2161D2F4FBC32B95", 16),
-                    Long.parseUnsignedLong("CBF83091BDB34092", 16),
-                    Long.parseUnsignedLong("D742CC0AD4CC7E38", 16),
-                    Long.parseUnsignedLong("61A1FA7E1B14FBD7", 16),
-                    Long.parseUnsignedLong("F0E5FC70137597C4", 16),
-                    Long.parseUnsignedLong("1F0C8F2585E20B1F", 16),
-                    Long.parseUnsignedLong("C68E44A1C032A4C2", 16),
-                    Long.parseUnsignedLong("E3C65FB8AF155A0D", 16),
-                    Long.parseUnsignedLong("00000001409EE8D5", 16)
+                    0xC6C8E180E41884BAL,
+                    0x2161D2F4FBC32B95L,
+                    0xCBF83091BDB34092L,
+                    0xD742CC0AD4CC7E38L,
+                    0x61A1FA7E1B14FBD7L,
+                    0xF0E5FC70137597C4L,
+                    0x1F0C8F2585E20B1FL,
+                    0xC68E44A1C032A4C2L,
+                    0xE3C65FB8AF155A0DL,
+                    0x00000001409EE8D5L
             });
             FpElement PUBLIC_POINT_PB_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16)
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L
             });
             FpElement PUBLIC_POINT_QB_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("F586DB4A16BE1880", 16),
-                    Long.parseUnsignedLong("712F10D95E6C65A9", 16),
-                    Long.parseUnsignedLong("9D5AAC3B83584B87", 16),
-                    Long.parseUnsignedLong("4ECDAA98182C8261", 16),
-                    Long.parseUnsignedLong("AD7D4C15588FD230", 16),
-                    Long.parseUnsignedLong("4197C54E96B7D926", 16),
-                    Long.parseUnsignedLong("ED15BB13E8C588ED", 16),
-                    Long.parseUnsignedLong("3E299AEAD5AAD7C7", 16),
-                    Long.parseUnsignedLong("F36B25F1BD579F79", 16),
-                    Long.parseUnsignedLong("000000021CE65B5B", 16)
+                    0xF586DB4A16BE1880L,
+                    0x712F10D95E6C65A9L,
+                    0x9D5AAC3B83584B87L,
+                    0x4ECDAA98182C8261L,
+                    0xAD7D4C15588FD230L,
+                    0x4197C54E96B7D926L,
+                    0xED15BB13E8C588EDL,
+                    0x3E299AEAD5AAD7C7L,
+                    0xF36B25F1BD579F79L,
+                    0x000000021CE65B5BL
             });
             FpElement PUBLIC_POINT_QB_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16)
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L
             });
             FpElement PUBLIC_POINT_RB_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("7A87897A0C4C3FD7", 16),
-                    Long.parseUnsignedLong("3C1879ECD4D33D76", 16),
-                    Long.parseUnsignedLong("595C28A36FFBA1A0", 16),
-                    Long.parseUnsignedLong("F53FF66A2A7FD0FB", 16),
-                    Long.parseUnsignedLong("B39F5A91230E56FA", 16),
-                    Long.parseUnsignedLong("81F21610DA3EA8B5", 16),
-                    Long.parseUnsignedLong("EBB3B9A627428A90", 16),
-                    Long.parseUnsignedLong("8661123B35748010", 16),
-                    Long.parseUnsignedLong("E196173B9C48781D", 16),
-                    Long.parseUnsignedLong("00000002198166AC", 16)
+                    0x7A87897A0C4C3FD7L,
+                    0x3C1879ECD4D33D76L,
+                    0x595C28A36FFBA1A0L,
+                    0xF53FF66A2A7FD0FBL,
+                    0xB39F5A91230E56FAL,
+                    0x81F21610DA3EA8B5L,
+                    0xEBB3B9A627428A90L,
+                    0x8661123B35748010L,
+                    0xE196173B9C48781DL,
+                    0x00000002198166ACL
             });
             FpElement PUBLIC_POINT_RB_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("5E3CC79B37006D6A", 16),
-                    Long.parseUnsignedLong("E0358A9AB2EA7923", 16),
-                    Long.parseUnsignedLong("3B725CB595180951", 16),
-                    Long.parseUnsignedLong("0724637F1DD0C191", 16),
-                    Long.parseUnsignedLong("7BB031B67DAB9D19", 16),
-                    Long.parseUnsignedLong("53CCB8BECEDD3435", 16),
-                    Long.parseUnsignedLong("EE5DF7FFEBFA7A0A", 16),
-                    Long.parseUnsignedLong("899EDB7D8B9694C4", 16),
-                    Long.parseUnsignedLong("0CA38EB4AE5506B6", 16),
-                    Long.parseUnsignedLong("00000001489DE1CD", 16)
+                    0x5E3CC79B37006D6AL,
+                    0xE0358A9AB2EA7923L,
+                    0x3B725CB595180951L,
+                    0x0724637F1DD0C191L,
+                    0x7BB031B67DAB9D19L,
+                    0x53CCB8BECEDD3435L,
+                    0xEE5DF7FFEBFA7A0AL,
+                    0x899EDB7D8B9694C4L,
+                    0x0CA38EB4AE5506B6L,
+                    0x00000001489DE1CDL
             });
             PUBLIC_POINT_PB = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_PB_X0, PUBLIC_POINT_PB_X1), fp2ElementFactory.one());
             PUBLIC_POINT_QB = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_QB_X0, PUBLIC_POINT_QB_X1), fp2ElementFactory.one());

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/param/SikeParamP751.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/param/SikeParamP751.java
@@ -261,18 +261,18 @@ public class SikeParamP751 implements SikeParam {
     }
 
     private final FpElementOpti p = new FpElementOpti(this, new long[]{
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("EEAFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("E3EC968549F878A8", 16),
-            Long.parseUnsignedLong("DA959B1A13F7CC76", 16),
-            Long.parseUnsignedLong("084E9867D6EBE876", 16),
-            Long.parseUnsignedLong("8562B5045CB25748", 16),
-            Long.parseUnsignedLong("0E12909F97BADC66", 16),
-            Long.parseUnsignedLong("00006FE5D541F71C", 16)
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xEEAFFFFFFFFFFFFFL,
+            0xE3EC968549F878A8L,
+            0xDA959B1A13F7CC76L,
+            0x084E9867D6EBE876L,
+            0x8562B5045CB25748L,
+            0x0E12909F97BADC66L,
+            0x00006FE5D541F71CL
     });
 
     @Override
@@ -281,18 +281,18 @@ public class SikeParamP751 implements SikeParam {
     }
 
     private final FpElementOpti p1 = new FpElementOpti(this, new long[]{
-            Long.parseUnsignedLong("0000000000000000", 16),
-            Long.parseUnsignedLong("0000000000000000", 16),
-            Long.parseUnsignedLong("0000000000000000", 16),
-            Long.parseUnsignedLong("0000000000000000", 16),
-            Long.parseUnsignedLong("0000000000000000", 16),
-            Long.parseUnsignedLong("EEB0000000000000", 16),
-            Long.parseUnsignedLong("E3EC968549F878A8", 16),
-            Long.parseUnsignedLong("DA959B1A13F7CC76", 16),
-            Long.parseUnsignedLong("084E9867D6EBE876", 16),
-            Long.parseUnsignedLong("8562B5045CB25748", 16),
-            Long.parseUnsignedLong("0E12909F97BADC66", 16),
-            Long.parseUnsignedLong("00006FE5D541F71C", 16)
+            0x0000000000000000L,
+            0x0000000000000000L,
+            0x0000000000000000L,
+            0x0000000000000000L,
+            0x0000000000000000L,
+            0xEEB0000000000000L,
+            0xE3EC968549F878A8L,
+            0xDA959B1A13F7CC76L,
+            0x084E9867D6EBE876L,
+            0x8562B5045CB25748L,
+            0x0E12909F97BADC66L,
+            0x00006FE5D541F71CL
     });
 
     @Override
@@ -301,18 +301,18 @@ public class SikeParamP751 implements SikeParam {
     }
 
     private final FpElementOpti px2 = new FpElementOpti(this, new long[]{
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFE", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("FFFFFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("DD5FFFFFFFFFFFFF", 16),
-            Long.parseUnsignedLong("C7D92D0A93F0F151", 16),
-            Long.parseUnsignedLong("B52B363427EF98ED", 16),
-            Long.parseUnsignedLong("109D30CFADD7D0ED", 16),
-            Long.parseUnsignedLong("0AC56A08B964AE90", 16),
-            Long.parseUnsignedLong("1C25213F2F75B8CD", 16),
-            Long.parseUnsignedLong("0000DFCBAA83EE38", 16)
+            0xFFFFFFFFFFFFFFFEL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xFFFFFFFFFFFFFFFFL,
+            0xDD5FFFFFFFFFFFFFL,
+            0xC7D92D0A93F0F151L,
+            0xB52B363427EF98EDL,
+            0x109D30CFADD7D0EDL,
+            0x0AC56A08B964AE90L,
+            0x1C25213F2F75B8CDL,
+            0x0000DFCBAA83EE38L
     });
 
     @Override
@@ -321,18 +321,18 @@ public class SikeParamP751 implements SikeParam {
     }
 
     private final FpElementOpti pr2 = new FpElementOpti(this, new long[]{
-            Long.parseUnsignedLong("233046449DAD4058", 16),
-            Long.parseUnsignedLong("DB010161A696452A", 16),
-            Long.parseUnsignedLong("5E36941472E3FD8E", 16),
-            Long.parseUnsignedLong("F40BFE2082A2E706", 16),
-            Long.parseUnsignedLong("4932CCA8904F8751", 16),
-            Long.parseUnsignedLong("1F735F1F1EE7FC81", 16),
-            Long.parseUnsignedLong("A24F4D80C1048E18", 16),
-            Long.parseUnsignedLong("B56C383CCDB607C5", 16),
-            Long.parseUnsignedLong("441DD47B735F9C90", 16),
-            Long.parseUnsignedLong("5673ED2C6A6AC82A", 16),
-            Long.parseUnsignedLong("06C905261132294B", 16),
-            Long.parseUnsignedLong("000041AD830F1F35", 16)
+            0x233046449DAD4058L,
+            0xDB010161A696452AL,
+            0x5E36941472E3FD8EL,
+            0xF40BFE2082A2E706L,
+            0x4932CCA8904F8751L,
+            0x1F735F1F1EE7FC81L,
+            0xA24F4D80C1048E18L,
+            0xB56C383CCDB607C5L,
+            0x441DD47B735F9C90L,
+            0x5673ED2C6A6AC82AL,
+            0x06C905261132294BL,
+            0x000041AD830F1F35L
     });
 
     @Override
@@ -406,175 +406,175 @@ public class SikeParamP751 implements SikeParam {
             PUBLIC_POINT_RB = new Fp2PointAffine(new Fp2ElementRef(this, PUBLIC_POINT_RB_X0, PUBLIC_POINT_RB_X1), new Fp2ElementRef(this, PUBLIC_POINT_RB_Y0, PUBLIC_POINT_RB_Y1));
         } else {
             FpElement PUBLIC_POINT_PA_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("884F46B74000BAA8", 16),
-                    Long.parseUnsignedLong("BA52630F939DEC20", 16),
-                    Long.parseUnsignedLong("C16FB97BA714A04D", 16),
-                    Long.parseUnsignedLong("082536745B1AB3DB", 16),
-                    Long.parseUnsignedLong("1117157F446F9E82", 16),
-                    Long.parseUnsignedLong("D2F27D621A018490", 16),
-                    Long.parseUnsignedLong("6B24AB523D544BCD", 16),
-                    Long.parseUnsignedLong("9307D6AA2EA85C94", 16),
-                    Long.parseUnsignedLong("E1A096729528F20F", 16),
-                    Long.parseUnsignedLong("896446F868F3255C", 16),
-                    Long.parseUnsignedLong("2401D996B1BFF8A5", 16),
-                    Long.parseUnsignedLong("00000EF8786A5C0A", 16)
+                    0x884F46B74000BAA8L,
+                    0xBA52630F939DEC20L,
+                    0xC16FB97BA714A04DL,
+                    0x082536745B1AB3DBL,
+                    0x1117157F446F9E82L,
+                    0xD2F27D621A018490L,
+                    0x6B24AB523D544BCDL,
+                    0x9307D6AA2EA85C94L,
+                    0xE1A096729528F20FL,
+                    0x896446F868F3255CL,
+                    0x2401D996B1BFF8A5L,
+                    0x00000EF8786A5C0AL
             });
             FpElement PUBLIC_POINT_PA_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("AEB78B3B96F59394", 16),
-                    Long.parseUnsignedLong("AB26681E29C90B74", 16),
-                    Long.parseUnsignedLong("E520AC30FDC4ACF1", 16),
-                    Long.parseUnsignedLong("870AAAE3A4B8111B", 16),
-                    Long.parseUnsignedLong("F875BDB738D64EFF", 16),
-                    Long.parseUnsignedLong("50109A7ECD7ED6BC", 16),
-                    Long.parseUnsignedLong("4CC64848FF0C56FB", 16),
-                    Long.parseUnsignedLong("E617CB6C519102C9", 16),
-                    Long.parseUnsignedLong("9C74B3835921E609", 16),
-                    Long.parseUnsignedLong("C91DDAE4A35A7146", 16),
-                    Long.parseUnsignedLong("7FC82A155C1B9129", 16),
-                    Long.parseUnsignedLong("0000214FA6B980B3", 16)
+                    0xAEB78B3B96F59394L,
+                    0xAB26681E29C90B74L,
+                    0xE520AC30FDC4ACF1L,
+                    0x870AAAE3A4B8111BL,
+                    0xF875BDB738D64EFFL,
+                    0x50109A7ECD7ED6BCL,
+                    0x4CC64848FF0C56FBL,
+                    0xE617CB6C519102C9L,
+                    0x9C74B3835921E609L,
+                    0xC91DDAE4A35A7146L,
+                    0x7FC82A155C1B9129L,
+                    0x0000214FA6B980B3L
             });
             FpElement PUBLIC_POINT_QA_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("0F93CC38680A8CA9", 16),
-                    Long.parseUnsignedLong("762E733822E7FED7", 16),
-                    Long.parseUnsignedLong("E549F005AC0ADB67", 16),
-                    Long.parseUnsignedLong("94A71FDD2C43A4ED", 16),
-                    Long.parseUnsignedLong("D48645C2B04721C5", 16),
-                    Long.parseUnsignedLong("432DA1FE4D4CA4DC", 16),
-                    Long.parseUnsignedLong("BC99655FAA7A80E8", 16),
-                    Long.parseUnsignedLong("B2C6D502BCFD4823", 16),
-                    Long.parseUnsignedLong("EE92F40CA2EC8BDB", 16),
-                    Long.parseUnsignedLong("7B074132EFB6D16C", 16),
-                    Long.parseUnsignedLong("3340B46FA38A7633", 16),
-                    Long.parseUnsignedLong("0000215749657F6C", 16)
+                    0x0F93CC38680A8CA9L,
+                    0x762E733822E7FED7L,
+                    0xE549F005AC0ADB67L,
+                    0x94A71FDD2C43A4EDL,
+                    0xD48645C2B04721C5L,
+                    0x432DA1FE4D4CA4DCL,
+                    0xBC99655FAA7A80E8L,
+                    0xB2C6D502BCFD4823L,
+                    0xEE92F40CA2EC8BDBL,
+                    0x7B074132EFB6D16CL,
+                    0x3340B46FA38A7633L,
+                    0x0000215749657F6CL
             });
             FpElement PUBLIC_POINT_QA_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("ECFF375BF3079F4C", 16),
-                    Long.parseUnsignedLong("FBFE74B043E80EF3", 16),
-                    Long.parseUnsignedLong("17376CBE3C5C7AD1", 16),
-                    Long.parseUnsignedLong("C06327A7E29CDBF2", 16),
-                    Long.parseUnsignedLong("2111649C438BF3D4", 16),
-                    Long.parseUnsignedLong("C1F9298261BA2E97", 16),
-                    Long.parseUnsignedLong("1F9FECE869CFD1C2", 16),
-                    Long.parseUnsignedLong("01A39B4FC9346D62", 16),
-                    Long.parseUnsignedLong("147CD1D3E82A3C9F", 16),
-                    Long.parseUnsignedLong("DE84E9D249E533EE", 16),
-                    Long.parseUnsignedLong("1C48A5ADFB7C578D", 16),
-                    Long.parseUnsignedLong("000061ACA0B82E1D", 16)
+                    0xECFF375BF3079F4CL,
+                    0xFBFE74B043E80EF3L,
+                    0x17376CBE3C5C7AD1L,
+                    0xC06327A7E29CDBF2L,
+                    0x2111649C438BF3D4L,
+                    0xC1F9298261BA2E97L,
+                    0x1F9FECE869CFD1C2L,
+                    0x01A39B4FC9346D62L,
+                    0x147CD1D3E82A3C9FL,
+                    0xDE84E9D249E533EEL,
+                    0x1C48A5ADFB7C578DL,
+                    0x000061ACA0B82E1DL
             });
             FpElement PUBLIC_POINT_RA_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("1600C525D41059F1", 16),
-                    Long.parseUnsignedLong("A596899A0A1D83F7", 16),
-                    Long.parseUnsignedLong("6BFDEED6D2B23F35", 16),
-                    Long.parseUnsignedLong("5C7E707270C23910", 16),
-                    Long.parseUnsignedLong("276CA1A4E8369411", 16),
-                    Long.parseUnsignedLong("B193651A602925A0", 16),
-                    Long.parseUnsignedLong("243D239F1CA1F04A", 16),
-                    Long.parseUnsignedLong("543DC6DA457860AD", 16),
-                    Long.parseUnsignedLong("CDA590F325181DE9", 16),
-                    Long.parseUnsignedLong("D3AB7ACFDA80B395", 16),
-                    Long.parseUnsignedLong("6C97468580FDDF7B", 16),
-                    Long.parseUnsignedLong("0000352A3E5C4C77", 16)
+                    0x1600C525D41059F1L,
+                    0xA596899A0A1D83F7L,
+                    0x6BFDEED6D2B23F35L,
+                    0x5C7E707270C23910L,
+                    0x276CA1A4E8369411L,
+                    0xB193651A602925A0L,
+                    0x243D239F1CA1F04AL,
+                    0x543DC6DA457860ADL,
+                    0xCDA590F325181DE9L,
+                    0xD3AB7ACFDA80B395L,
+                    0x6C97468580FDDF7BL,
+                    0x0000352A3E5C4C77L
             });
             FpElement PUBLIC_POINT_RA_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("9B794F9FD1CC3EE8", 16),
-                    Long.parseUnsignedLong("DB32E40A9B2FD23E", 16),
-                    Long.parseUnsignedLong("26192A2542E42B67", 16),
-                    Long.parseUnsignedLong("A18E94FCA045BCE7", 16),
-                    Long.parseUnsignedLong("96DC1BC38E7CDA2D", 16),
-                    Long.parseUnsignedLong("9A1D91B752487DE2", 16),
-                    Long.parseUnsignedLong("CC63763987436DA3", 16),
-                    Long.parseUnsignedLong("1316717AACCC551D", 16),
-                    Long.parseUnsignedLong("C4C368A4632AFE72", 16),
-                    Long.parseUnsignedLong("4B6EA85C9CCD5710", 16),
-                    Long.parseUnsignedLong("7A12CAD582C7BC9A", 16),
-                    Long.parseUnsignedLong("00001C7E240149BF", 16)
+                    0x9B794F9FD1CC3EE8L,
+                    0xDB32E40A9B2FD23EL,
+                    0x26192A2542E42B67L,
+                    0xA18E94FCA045BCE7L,
+                    0x96DC1BC38E7CDA2DL,
+                    0x9A1D91B752487DE2L,
+                    0xCC63763987436DA3L,
+                    0x1316717AACCC551DL,
+                    0xC4C368A4632AFE72L,
+                    0x4B6EA85C9CCD5710L,
+                    0x7A12CAD582C7BC9AL,
+                    0x00001C7E240149BFL
             });
             PUBLIC_POINT_PA = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_PA_X0, PUBLIC_POINT_PA_X1), fp2ElementFactory.one());
             PUBLIC_POINT_QA = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_QA_X0, PUBLIC_POINT_QA_X1), fp2ElementFactory.one());
             PUBLIC_POINT_RA = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_RA_X0, PUBLIC_POINT_RA_X1), fp2ElementFactory.one());
             FpElement PUBLIC_POINT_PB_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("85691AAF4015F88C", 16),
-                    Long.parseUnsignedLong("7478C5B8C36E9631", 16),
-                    Long.parseUnsignedLong("7EF2A185DE4DD6E2", 16),
-                    Long.parseUnsignedLong("943BBEE46BEB9DC7", 16),
-                    Long.parseUnsignedLong("1A3EC62798792D22", 16),
-                    Long.parseUnsignedLong("791BC4B084B31D69", 16),
-                    Long.parseUnsignedLong("03DBE6522CEA17C4", 16),
-                    Long.parseUnsignedLong("04749AA65D665D83", 16),
-                    Long.parseUnsignedLong("3D52B5C45EF450F3", 16),
-                    Long.parseUnsignedLong("0B4219848E36947D", 16),
-                    Long.parseUnsignedLong("A4CF7070466BDE27", 16),
-                    Long.parseUnsignedLong("0000334B1FA6D193", 16)
+                    0x85691AAF4015F88CL,
+                    0x7478C5B8C36E9631L,
+                    0x7EF2A185DE4DD6E2L,
+                    0x943BBEE46BEB9DC7L,
+                    0x1A3EC62798792D22L,
+                    0x791BC4B084B31D69L,
+                    0x03DBE6522CEA17C4L,
+                    0x04749AA65D665D83L,
+                    0x3D52B5C45EF450F3L,
+                    0x0B4219848E36947DL,
+                    0xA4CF7070466BDE27L,
+                    0x0000334B1FA6D193L
             });
             FpElement PUBLIC_POINT_PB_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16)
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L
             });
             FpElement PUBLIC_POINT_QB_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("8E7CB3FA53211340", 16),
-                    Long.parseUnsignedLong("D67CE54F7A05EEE0", 16),
-                    Long.parseUnsignedLong("FDDC2C8BCE46FC38", 16),
-                    Long.parseUnsignedLong("08587FAE3110DF1E", 16),
-                    Long.parseUnsignedLong("D6B8246FA22B058B", 16),
-                    Long.parseUnsignedLong("4DAC3ACC905A5DBD", 16),
-                    Long.parseUnsignedLong("51D0BF2FADCED3E8", 16),
-                    Long.parseUnsignedLong("E5A2406DF6484425", 16),
-                    Long.parseUnsignedLong("907F177584F671B8", 16),
-                    Long.parseUnsignedLong("4738A2FFCCED051C", 16),
-                    Long.parseUnsignedLong("2B0067B4177E4853", 16),
-                    Long.parseUnsignedLong("00002806AC948D3D", 16)
+                    0x8E7CB3FA53211340L,
+                    0xD67CE54F7A05EEE0L,
+                    0xFDDC2C8BCE46FC38L,
+                    0x08587FAE3110DF1EL,
+                    0xD6B8246FA22B058BL,
+                    0x4DAC3ACC905A5DBDL,
+                    0x51D0BF2FADCED3E8L,
+                    0xE5A2406DF6484425L,
+                    0x907F177584F671B8L,
+                    0x4738A2FFCCED051CL,
+                    0x2B0067B4177E4853L,
+                    0x00002806AC948D3DL
             });
             FpElement PUBLIC_POINT_QB_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16),
-                    Long.parseUnsignedLong("0000000000000000", 16)
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L,
+                    0x0000000000000000L
             });
             FpElement PUBLIC_POINT_RB_X0 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("B56457016D1D6D1C", 16),
-                    Long.parseUnsignedLong("03DECCB38F39C491", 16),
-                    Long.parseUnsignedLong("DFB910AC8A559452", 16),
-                    Long.parseUnsignedLong("A9D0F17D1FF24883", 16),
-                    Long.parseUnsignedLong("8562BBAF515C248C", 16),
-                    Long.parseUnsignedLong("249B2A6DDB1CB67D", 16),
-                    Long.parseUnsignedLong("3131AF96FB46835C", 16),
-                    Long.parseUnsignedLong("E10258398480C3E1", 16),
-                    Long.parseUnsignedLong("EAB5E2B872D4FAB1", 16),
-                    Long.parseUnsignedLong("B71E63875FAEB1DF", 16),
-                    Long.parseUnsignedLong("F8384D4F13757CF6", 16),
-                    Long.parseUnsignedLong("0000361EC9B09912", 16)
+                    0xB56457016D1D6D1CL,
+                    0x03DECCB38F39C491L,
+                    0xDFB910AC8A559452L,
+                    0xA9D0F17D1FF24883L,
+                    0x8562BBAF515C248CL,
+                    0x249B2A6DDB1CB67DL,
+                    0x3131AF96FB46835CL,
+                    0xE10258398480C3E1L,
+                    0xEAB5E2B872D4FAB1L,
+                    0xB71E63875FAEB1DFL,
+                    0xF8384D4F13757CF6L,
+                    0x0000361EC9B09912L
             });
             FpElement PUBLIC_POINT_RB_X1 = new FpElementOpti(this,  new long[]{
-                    Long.parseUnsignedLong("58C967899ED16EF4", 16),
-                    Long.parseUnsignedLong("81998376DC622A4B", 16),
-                    Long.parseUnsignedLong("3D1C1DCFE0B12681", 16),
-                    Long.parseUnsignedLong("9347DEBB953E1730", 16),
-                    Long.parseUnsignedLong("9ABB344D3A82C2D7", 16),
-                    Long.parseUnsignedLong("E4881BD2820552B2", 16),
-                    Long.parseUnsignedLong("0037247923D90266", 16),
-                    Long.parseUnsignedLong("2E3156EDB157E5A5", 16),
-                    Long.parseUnsignedLong("F86A46A7506823F7", 16),
-                    Long.parseUnsignedLong("8FE5523A7B7F1CFC", 16),
-                    Long.parseUnsignedLong("FA3CFFA38372F67B", 16),
-                    Long.parseUnsignedLong("0000692DCE85FFBD", 16)
+                    0x58C967899ED16EF4L,
+                    0x81998376DC622A4BL,
+                    0x3D1C1DCFE0B12681L,
+                    0x9347DEBB953E1730L,
+                    0x9ABB344D3A82C2D7L,
+                    0xE4881BD2820552B2L,
+                    0x0037247923D90266L,
+                    0x2E3156EDB157E5A5L,
+                    0xF86A46A7506823F7L,
+                    0x8FE5523A7B7F1CFCL,
+                    0xFA3CFFA38372F67BL,
+                    0x0000692DCE85FFBDL
             });
             PUBLIC_POINT_PB = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_PB_X0, PUBLIC_POINT_PB_X1), fp2ElementFactory.one());
             PUBLIC_POINT_QB = new Fp2PointProjective(new Fp2ElementOpti(this, PUBLIC_POINT_QB_X0, PUBLIC_POINT_QB_X1), fp2ElementFactory.one());

--- a/sike-java/src/test/java/com/wultra/security/pqc/sike/OctetEncodingTest.java
+++ b/sike-java/src/test/java/com/wultra/security/pqc/sike/OctetEncodingTest.java
@@ -68,13 +68,13 @@ class OctetEncodingTest {
         SikeParam sikeParam = new SikeParamP434(ImplementationType.OPTIMIZED);
         FpElementOpti one = new FpElementOpti(sikeParam, new BigInteger("1"));
         assertArrayEquals(new long[]{
-                Long.parseUnsignedLong("000000000000742C", 16),
-                Long.parseUnsignedLong("0000000000000000", 16),
-                Long.parseUnsignedLong("0000000000000000", 16),
-                Long.parseUnsignedLong("B90FF404FC000000", 16),
-                Long.parseUnsignedLong("D801A4FB559FACD4", 16),
-                Long.parseUnsignedLong("E93254545F77410C", 16),
-                Long.parseUnsignedLong("0000ECEEA7BD2EDA", 16)
+                0x000000000000742CL,
+                0x0000000000000000L,
+                0x0000000000000000L,
+                0xB90FF404FC000000L,
+                0xD801A4FB559FACD4L,
+                0xE93254545F77410CL,
+                0x0000ECEEA7BD2EDAL
         }, one.getValue());
         String octetString = one.toOctetString();
         assertEquals("01000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", octetString);
@@ -85,13 +85,13 @@ class OctetEncodingTest {
     void testConversionFromMontgomeryP434() {
         SikeParam sikeParam = new SikeParamP434(ImplementationType.OPTIMIZED);
         FpElementOpti six = new FpElementOpti(sikeParam, new long[]{
-                Long.parseUnsignedLong("000000000002B90A", 16),
-                Long.parseUnsignedLong("0000000000000000", 16),
-                Long.parseUnsignedLong("0000000000000000", 16),
-                Long.parseUnsignedLong("5ADCCB2822000000", 16),
-                Long.parseUnsignedLong("187D24F39F0CAFB4", 16),
-                Long.parseUnsignedLong("9D353A4D394145A0", 16),
-                Long.parseUnsignedLong("00012559A0403298", 16)
+                0x000000000002B90AL,
+                0x0000000000000000L,
+                0x0000000000000000L,
+                0x5ADCCB2822000000L,
+                0x187D24F39F0CAFB4L,
+                0x9D353A4D394145A0L,
+                0x00012559A0403298L
         });
         String octetString = six.toOctetString();
         assertEquals("06000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", octetString);
@@ -103,13 +103,13 @@ class OctetEncodingTest {
         SikeParam sikeParam = new SikeParamP434(ImplementationType.OPTIMIZED);
         FpElementOpti six = new FpElementOpti(sikeParam, new BigInteger("6"));
         assertArrayEquals(new long[]{
-                Long.parseUnsignedLong("000000000002B90A", 16),
-                Long.parseUnsignedLong("0000000000000000", 16),
-                Long.parseUnsignedLong("0000000000000000", 16),
-                Long.parseUnsignedLong("5ADCCB2822000000", 16),
-                Long.parseUnsignedLong("187D24F39F0CAFB4", 16),
-                Long.parseUnsignedLong("9D353A4D394145A0", 16),
-                Long.parseUnsignedLong("00012559A0403298", 16)
+                0x000000000002B90AL,
+                0x0000000000000000L,
+                0x0000000000000000L,
+                0x5ADCCB2822000000L,
+                0x187D24F39F0CAFB4L,
+                0x9D353A4D394145A0L,
+                0x00012559A0403298L
         }, six.getValue());
         String octetString = six.toOctetString();
         assertEquals("06000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", octetString);
@@ -120,14 +120,14 @@ class OctetEncodingTest {
     void testConversionFromMontgomeryP503() {
         SikeParam sikeParam = new SikeParamP503(ImplementationType.OPTIMIZED);
         FpElementOpti six = new FpElementOpti(sikeParam, new long[]{
-                Long.parseUnsignedLong("00000000000017D8", 16),
-                Long.parseUnsignedLong("0000000000000000", 16),
-                Long.parseUnsignedLong("0000000000000000", 16),
-                Long.parseUnsignedLong("E000000000000000", 16),
-                Long.parseUnsignedLong("30B1E6E3A51520FA", 16),
-                Long.parseUnsignedLong("B13BC3BF6FFB3992", 16),
-                Long.parseUnsignedLong("8045412EEB3E3DED", 16),
-                Long.parseUnsignedLong("0069182E2159DBB8", 16)
+                0x00000000000017D8L,
+                0x0000000000000000L,
+                0x0000000000000000L,
+                0xE000000000000000L,
+                0x30B1E6E3A51520FAL,
+                0xB13BC3BF6FFB3992L,
+                0x8045412EEB3E3DEDL,
+                0x0069182E2159DBB8L
         });
         String octetString = six.toOctetString();
         assertEquals("060000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", octetString);
@@ -138,16 +138,16 @@ class OctetEncodingTest {
     void testConversionFromMontgomeryP610() {
         SikeParam sikeParam = new SikeParamP610(ImplementationType.OPTIMIZED);
         FpElementOpti one = new FpElementOpti(sikeParam, new long[]{
-                Long.parseUnsignedLong("00000000670CC8E6", 16),
-                Long.parseUnsignedLong("0000000000000000", 16),
-                Long.parseUnsignedLong("0000000000000000", 16),
-                Long.parseUnsignedLong("0000000000000000", 16),
-                Long.parseUnsignedLong("9A34000000000000", 16),
-                Long.parseUnsignedLong("4D99C2BD28717A3F", 16),
-                Long.parseUnsignedLong("0A4A1839A323D41C", 16),
-                Long.parseUnsignedLong("D2B62215D06AD1E2", 16),
-                Long.parseUnsignedLong("1369026E862CAF3D", 16),
-                Long.parseUnsignedLong("000000010894E964", 16)
+                0x00000000670CC8E6L,
+                0x0000000000000000L,
+                0x0000000000000000L,
+                0x0000000000000000L,
+                0x9A34000000000000L,
+                0x4D99C2BD28717A3FL,
+                0x0A4A1839A323D41CL,
+                0xD2B62215D06AD1E2L,
+                0x1369026E862CAF3DL,
+                0x000000010894E964L
         });
         String octetString = one.toOctetString();
         assertEquals("0100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", octetString);
@@ -158,18 +158,18 @@ class OctetEncodingTest {
     void testConversionFromMontgomeryP751() {
         SikeParam sikeParam = new SikeParamP751(ImplementationType.OPTIMIZED);
         FpElementOpti one = new FpElementOpti(sikeParam, new long[]{
-                Long.parseUnsignedLong("00000000000249AD", 16),
-                Long.parseUnsignedLong("0000000000000000", 16),
-                Long.parseUnsignedLong("0000000000000000", 16),
-                Long.parseUnsignedLong("0000000000000000", 16),
-                Long.parseUnsignedLong("0000000000000000", 16),
-                Long.parseUnsignedLong("8310000000000000", 16),
-                Long.parseUnsignedLong("5527B1E4375C6C66", 16),
-                Long.parseUnsignedLong("697797BF3F4F24D0", 16),
-                Long.parseUnsignedLong("C89DB7B2AC5C4E2E", 16),
-                Long.parseUnsignedLong("4CA4B439D2076956", 16),
-                Long.parseUnsignedLong("10F7926C7512C7E9", 16),
-                Long.parseUnsignedLong("00002D5B24BCE5E2", 16)
+                0x00000000000249ADL,
+                0x0000000000000000L,
+                0x0000000000000000L,
+                0x0000000000000000L,
+                0x0000000000000000L,
+                0x8310000000000000L,
+                0x5527B1E4375C6C66L,
+                0x697797BF3F4F24D0L,
+                0xC89DB7B2AC5C4E2EL,
+                0x4CA4B439D2076956L,
+                0x10F7926C7512C7E9L,
+                0x00002D5B24BCE5E2L
         });
         String octetString = one.toOctetString();
         assertEquals("01000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", octetString);

--- a/sike-java/src/test/java/com/wultra/security/pqc/sike/math/FpMathTest.java
+++ b/sike-java/src/test/java/com/wultra/security/pqc/sike/math/FpMathTest.java
@@ -116,22 +116,22 @@ class FpMathTest {
     @Test
     void testFpSwapCondTrue() {
         FpElementOpti x = new FpElementOpti(sikeParam, new long[]{
-                Long.parseUnsignedLong("05ADF455C5C345BF", 16),
-                Long.parseUnsignedLong("91935C5CC767AC2B", 16),
-                Long.parseUnsignedLong("AFE4E879951F0257", 16),
-                Long.parseUnsignedLong("70E792DC89FA27B1", 16),
-                Long.parseUnsignedLong("F797F526BB48C8CD", 16),
-                Long.parseUnsignedLong("2181DB6131AF621F", 16),
-                Long.parseUnsignedLong("00000A1C08B1ECC4", 16)
+                0x05ADF455C5C345BFL,
+                0x91935C5CC767AC2BL,
+                0xAFE4E879951F0257L,
+                0x70E792DC89FA27B1L,
+                0xF797F526BB48C8CDL,
+                0x2181DB6131AF621FL,
+                0x00000A1C08B1ECC4L
         });
         FpElementOpti y = new FpElementOpti(sikeParam, new long[]{
-                Long.parseUnsignedLong("6E5497556EDD48A3", 16),
-                Long.parseUnsignedLong("2A61B501546F1C05", 16),
-                Long.parseUnsignedLong("EB919446D049887D", 16),
-                Long.parseUnsignedLong("5864A4A69D450C4F", 16),
-                Long.parseUnsignedLong("B883F276A6490D2B", 16),
-                Long.parseUnsignedLong("22CC287022D5F5B9", 16),
-                Long.parseUnsignedLong("0001BED4772E551F", 16)
+                0x6E5497556EDD48A3L,
+                0x2A61B501546F1C05L,
+                0xEB919446D049887DL,
+                0x5864A4A69D450C4FL,
+                0xB883F276A6490D2BL,
+                0x22CC287022D5F5B9L,
+                0x0001BED4772E551FL
         });
         FpElement xCopy = x.copy();
         FpElement yCopy = y.copy();
@@ -143,22 +143,22 @@ class FpMathTest {
     @Test
     void testFpSwapCondFalse() {
         FpElementOpti x = new FpElementOpti(sikeParam, new long[]{
-                Long.parseUnsignedLong("05ADF455C5C345BF", 16),
-                Long.parseUnsignedLong("91935C5CC767AC2B", 16),
-                Long.parseUnsignedLong("AFE4E879951F0257", 16),
-                Long.parseUnsignedLong("70E792DC89FA27B1", 16),
-                Long.parseUnsignedLong("F797F526BB48C8CD", 16),
-                Long.parseUnsignedLong("2181DB6131AF621F", 16),
-                Long.parseUnsignedLong("00000A1C08B1ECC4", 16)
+                0x05ADF455C5C345BFL,
+                0x91935C5CC767AC2BL,
+                0xAFE4E879951F0257L,
+                0x70E792DC89FA27B1L,
+                0xF797F526BB48C8CDL,
+                0x2181DB6131AF621FL,
+                0x00000A1C08B1ECC4L
         });
         FpElementOpti y = new FpElementOpti(sikeParam, new long[]{
-                Long.parseUnsignedLong("6E5497556EDD48A3", 16),
-                Long.parseUnsignedLong("2A61B501546F1C05", 16),
-                Long.parseUnsignedLong("EB919446D049887D", 16),
-                Long.parseUnsignedLong("5864A4A69D450C4F", 16),
-                Long.parseUnsignedLong("B883F276A6490D2B", 16),
-                Long.parseUnsignedLong("22CC287022D5F5B9", 16),
-                Long.parseUnsignedLong("0001BED4772E551F", 16)
+                0x6E5497556EDD48A3L,
+                0x2A61B501546F1C05L,
+                0xEB919446D049887DL,
+                0x5864A4A69D450C4FL,
+                0xB883F276A6490D2BL,
+                0x22CC287022D5F5B9L,
+                0x0001BED4772E551FL
         });
         FpElement xCopy = x.copy();
         FpElement yCopy = y.copy();
@@ -214,38 +214,38 @@ class FpMathTest {
     @Test
     void testFpMul() {
         FpElementOpti x = new FpElementOpti(sikeParam, new long[]{
-                Long.parseUnsignedLong("05ADF455C5C345BF", 16),
-                Long.parseUnsignedLong("91935C5CC767AC2B", 16),
-                Long.parseUnsignedLong("AFE4E879951F0257", 16),
-                Long.parseUnsignedLong("70E792DC89FA27B1", 16),
-                Long.parseUnsignedLong("F797F526BB48C8CD", 16),
-                Long.parseUnsignedLong("2181DB6131AF621F", 16),
-                Long.parseUnsignedLong("00000A1C08B1ECC4", 16)
+                0x05ADF455C5C345BFL,
+                0x91935C5CC767AC2BL,
+                0xAFE4E879951F0257L,
+                0x70E792DC89FA27B1L,
+                0xF797F526BB48C8CDL,
+                0x2181DB6131AF621FL,
+                0x00000A1C08B1ECC4L
         });
         FpElementOpti y = new FpElementOpti(sikeParam, new long[]{
-                Long.parseUnsignedLong("6E5497556EDD48A3", 16),
-                Long.parseUnsignedLong("2A61B501546F1C05", 16),
-                Long.parseUnsignedLong("EB919446D049887D", 16),
-                Long.parseUnsignedLong("5864A4A69D450C4F", 16),
-                Long.parseUnsignedLong("B883F276A6490D2B", 16),
-                Long.parseUnsignedLong("22CC287022D5F5B9", 16),
-                Long.parseUnsignedLong("0001BED4772E551F", 16)
+                0x6E5497556EDD48A3L,
+                0x2A61B501546F1C05L,
+                0xEB919446D049887DL,
+                0x5864A4A69D450C4FL,
+                0xB883F276A6490D2BL,
+                0x22CC287022D5F5B9L,
+                0x0001BED4772E551FL
         });
         FpElementOpti expected = new FpElementOpti(sikeParam, new long[]{
-                Long.parseUnsignedLong("202625321ED6209D", 16),
-                Long.parseUnsignedLong("E5C308F0E445240D", 16),
-                Long.parseUnsignedLong("AFEB6AE1CAB32EEE", 16),
-                Long.parseUnsignedLong("639387B1A8C840D5", 16),
-                Long.parseUnsignedLong("49688D3E3451B61C", 16),
-                Long.parseUnsignedLong("ECFC874B5CA69C20", 16),
-                Long.parseUnsignedLong("F5CF44DB153217C8", 16),
-                Long.parseUnsignedLong("A63433819DD3DB5A", 16),
-                Long.parseUnsignedLong("7C4C549B441B950B", 16),
-                Long.parseUnsignedLong("C2B2CC10DE04DE6E", 16),
-                Long.parseUnsignedLong("4B09D74EB1DD4601", 16),
-                Long.parseUnsignedLong("F814733B29B69DB1", 16),
-                Long.parseUnsignedLong("A46937B9CCE8C76", 16),
-                Long.parseUnsignedLong("11A53B12", 16)
+                0x202625321ED6209DL,
+                0xE5C308F0E445240DL,
+                0xAFEB6AE1CAB32EEEL,
+                0x639387B1A8C840D5L,
+                0x49688D3E3451B61CL,
+                0xECFC874B5CA69C20L,
+                0xF5CF44DB153217C8L,
+                0xA63433819DD3DB5AL,
+                0x7C4C549B441B950BL,
+                0xC2B2CC10DE04DE6EL,
+                0x4B09D74EB1DD4601L,
+                0xF814733B29B69DB1L,
+                0xA46937B9CCE8C76L,
+                0x11A53B12L
         });
         assertEquals(expected, x.multiply(y));
     }


### PR DESCRIPTION
There were a bunch of calls to new helper functions that didn't seem to really be necessary, and which are not available on older versions of Android.  I replaced them with what I believe to be functionally equivalent code.  So far as my tests have gone, it seems to work - though there could be other functions present, unavailable on Android, that will crash the code if encountered (on Android).  On other systems, I believe there should be no functional difference.

The library is SUPER slow on Android, though, haha.