### PR TITLE
Fix #62: Use Arrays.hashCode for arrays, unify hashCode implementations with arrays

### DIFF
--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/model/EncapsulationResult.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/model/EncapsulationResult.java
@@ -69,8 +69,6 @@ public class EncapsulationResult {
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(encryptedMessage);
-        result = 31 * result + Arrays.hashCode(secret);
-        return result;
+        return Objects.hash(encryptedMessage, Arrays.hashCode(secret));
     }
 }

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/model/EncryptedMessage.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/model/EncryptedMessage.java
@@ -109,8 +109,6 @@ public class EncryptedMessage {
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(c0);
-        result = 31 * result + Arrays.hashCode(c1);
-        return result;
+        return Objects.hash(c0, Arrays.hashCode(c1));
     }
 }

--- a/sike-java/src/main/java/com/wultra/security/pqc/sike/model/SidhPrivateKey.java
+++ b/sike-java/src/main/java/com/wultra/security/pqc/sike/model/SidhPrivateKey.java
@@ -26,6 +26,7 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidParameterException;
 import java.security.PrivateKey;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -238,6 +239,6 @@ public class SidhPrivateKey implements PrivateKey {
 
     @Override
     public int hashCode() {
-        return Objects.hash(sikeParam, s, key);
+        return Objects.hash(sikeParam, Arrays.hashCode(s), Arrays.hashCode(key));
     }
 }


### PR DESCRIPTION
I fixed hashCode in class `SidhPrivateKey`. The other two changes are just unifications of hashCode implementations.